### PR TITLE
fix: encode illegal container and blob names

### DIFF
--- a/src/Xemo.Azure/EncodedBlobName.cs
+++ b/src/Xemo.Azure/EncodedBlobName.cs
@@ -1,0 +1,21 @@
+using Tonga.Text;
+
+namespace Xemo.Azure;
+
+/// <summary>
+/// A name encoded so that it can be used as azure blob name.
+/// </summary>
+public sealed class EncodedBlobName(string origin) : TextEnvelope(
+    AsText._(() => Encoded(origin))
+)
+{
+    private static string Encoded(string blobName)
+    {
+        string encodedName = Uri.EscapeDataString(blobName);
+        if (encodedName.EndsWith("/") || encodedName.EndsWith("."))
+        {
+            encodedName = encodedName.TrimEnd('/', '.');
+        }
+        return encodedName;
+    }    
+}

--- a/src/Xemo.Azure/EncodedContainerName.cs
+++ b/src/Xemo.Azure/EncodedContainerName.cs
@@ -1,0 +1,42 @@
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Tonga.Text;
+
+namespace Xemo.Azure;
+
+/// <summary>
+/// A name escaped so that it can be used as identifier for azure containers.
+/// </summary>
+public sealed class EncodedContainerName(string origin) : TextEnvelope(
+    AsText._(() => $"{Escaped(origin)}")
+)
+{
+    private static readonly char[] base36Chars = 
+        "0123456789abcdefghijklmnopqrstuvwxyz".ToCharArray();
+    private static string Escaped(string subject)
+    {
+        using SHA256 sha256 = SHA256.Create();
+        var legalized = Regex.Replace(subject, @"[^a-zA-Z0-9-]", "-");
+        var maxLength = 54;
+        legalized = legalized.Length <= maxLength ? legalized : legalized.Substring(0, maxLength);
+        return 
+            $"{legalized}-{
+                AsBase36(sha256.ComputeHash(Encoding.UTF8.GetBytes(subject)))
+                }";
+    }
+
+    private static string AsBase36(byte[] bytes)
+    {
+        BigInteger bigInt = new BigInteger(bytes.Concat(new byte[] { 0 }).ToArray());
+        StringBuilder result = new StringBuilder();
+        while (bigInt > 0)
+        {
+            bigInt = BigInteger.DivRem(bigInt, 36, out BigInteger remainder);
+            result.Insert(0, base36Chars[(int)remainder]);
+        }
+        var hash = result.ToString();
+        return hash.Substring(0, Math.Min(hash.Length, 8));
+    }
+}

--- a/src/Xemo/Cluster/Probe/LazySample.cs
+++ b/src/Xemo/Cluster/Probe/LazySample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Xemo.Cluster
+﻿namespace Xemo.Cluster.Probe
 {
     /// <summary>
     /// Simple sample.

--- a/tests/Xemo.Azure.Tests/Blob/BlobClusterTests.cs
+++ b/tests/Xemo.Azure.Tests/Blob/BlobClusterTests.cs
@@ -29,11 +29,14 @@ public sealed class BlobClusterTests
                 )
             );
 
-        var container = blobClient.GetBlobContainerClient(subject);
+        var container = 
+            blobClient.GetBlobContainerClient(
+                new EncodedContainerName(subject).AsString()
+            );
         container.CreateIfNotExists();
         try
         {
-            container.GetBlobClient(id1)
+            container.GetBlobClient(new EncodedBlobName(id1).AsString())
                 .Upload(
                     new MemoryStream(
                         Encoding.UTF8.GetBytes(
@@ -45,7 +48,7 @@ public sealed class BlobClusterTests
                         )
                     )
                 );
-            container.GetBlobClient(id2)
+            container.GetBlobClient(new EncodedBlobName(id2).AsString())
                 .Upload(
                     new MemoryStream(
                         Encoding.UTF8.GetBytes(

--- a/tests/Xemo.Azure.Tests/EncodedBlobNameTest.cs
+++ b/tests/Xemo.Azure.Tests/EncodedBlobNameTest.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace Xemo.Azure.Tests;
+
+public sealed class EncodedBlobNameTest
+{
+    [Fact]
+    public void Encodes()
+    {
+        Assert.Equal(
+            "ABC%21%40%23%24%25%5E%26%2A%28%29%2B%3D",
+            new EncodedBlobName("ABC!@#$%^&*()+=").AsString()    
+        );
+    }
+    
+    [Fact]
+    public void TrimsIllegalEnd()
+    {
+        Assert.Equal(
+            "ABC",
+            new EncodedBlobName($"ABC.").AsString()    
+        );
+    }
+    
+}

--- a/tests/Xemo.Azure.Tests/EncodedContainerNameTests.cs
+++ b/tests/Xemo.Azure.Tests/EncodedContainerNameTests.cs
@@ -1,0 +1,46 @@
+using Xunit;
+
+namespace Xemo.Azure.Tests;
+
+public sealed class EncodedContainerNameTests
+{
+    [Fact]
+    public void RemovesInvalidChars()
+    {
+        Assert.Equal(
+            "ABC--------------14qi1wxx",
+            new EncodedContainerName("ABC!@#$%^&*()_+=").AsString()
+        );
+    }
+    
+    [Fact]
+    public void PreservesDifferences()
+    {
+        Assert.NotEqual(
+            new EncodedContainerName("ABC?").AsString(),
+            new EncodedContainerName("ABC!").AsString()
+        );
+    }
+    
+    [Fact]
+    public void ShortensIfNecessary()
+    {
+        Assert.Equal(
+            63,
+            new EncodedContainerName("QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm0123456789")
+                .AsString()
+                .Length
+        );
+    }
+    
+    [Fact]
+    public void ShorteningKeepsDifferences()
+    {
+        Assert.NotEqual(
+            new EncodedContainerName("QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm0123456789")
+                .AsString(),
+            new EncodedContainerName("QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm012345678U")
+                .AsString()
+        );
+    }
+}


### PR DESCRIPTION
Names are now encoded accoring to the specs.
No migration available due to alpha status.